### PR TITLE
add AWSCore 0.1 lower bound to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,6 @@
 julia 0.5
-AWSCore
+AWSCore 0.1
+SymDict
+Retry
+Nettle
+URIParser


### PR DESCRIPTION
since it's the first version where AWSConfig is defined

also add direct dependencies on SymDict, Retry, Nettle, URIParser which are imported but not
directly depended on (assumed to be present as transitive deps)