### PR TITLE
send message with options

### DIFF
--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -189,7 +189,7 @@ Send a `message` to a queue.
 """
 function sqs_send_message(queue::AWSQueue, message::String, options...)
 
-    sqs(queue, "SendMessage",
+    sqs(queue, "SendMessage";
                MessageBody = message,
                MD5OfMessageBody = string(digest(MD_MD5, message)),
                options...

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -199,7 +199,6 @@ function sqs_send_message(queue::AWSQueue, message::String, groupId::String)
     sqs(queue, "SendMessage",
                MessageBody = message,
                MessageGroupId = groupId,
-               MessageDeduplicationId = string(digest(MD_MD5, groupId*message)),
                MD5OfMessageBody = string(digest(MD_MD5, message)))
 end
 

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -194,6 +194,14 @@ function sqs_send_message(queue::AWSQueue, message)
                MD5OfMessageBody = string(digest(MD_MD5, message)))
 end
 
+function sqs_send_message(queue::AWSQueue, message::String, groupId::String)
+
+    sqs(queue, "SendMessage",
+               MessageBody = message,
+               MessageGroupId = groupId,
+               MD5OfMessageBody = string(digest(MD_MD5, message)))
+end
+
 
 """
     sqs_send_message_batch(::AWSQueue, messages)

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -183,7 +183,8 @@ end
 
 
 """
-    sqs_send_message(::AWSQueue, message)
+    sqs_send_message(::AWSQueue, message, options...)
+    ex: sqs_send_message(q, "Hello2", Dict(:MessageGroupId=>"interestGid")...)
 
 Send a `message` to a queue.
 """
@@ -194,14 +195,6 @@ function sqs_send_message(queue::AWSQueue, message::String, options...)
                MD5OfMessageBody = string(digest(MD_MD5, message)),
                options...
        )
-end
-
-function sqs_send_message(queue::AWSQueue, message::String, groupId::String)
-
-    sqs(queue, "SendMessage",
-               MessageBody = message,
-               MessageGroupId = groupId,
-               MD5OfMessageBody = string(digest(MD_MD5, message)))
 end
 
 

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -199,6 +199,7 @@ function sqs_send_message(queue::AWSQueue, message::String, groupId::String)
     sqs(queue, "SendMessage",
                MessageBody = message,
                MessageGroupId = groupId,
+               MessageDeduplicationId = string(digest(MD_MD5, groupId*message)),
                MD5OfMessageBody = string(digest(MD_MD5, message)))
 end
 

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -190,9 +190,10 @@ Send a `message` to a queue.
 function sqs_send_message(queue::AWSQueue, message::String, options...)
 
     sqs(queue, "SendMessage",
-               options,
                MessageBody = message,
-               MD5OfMessageBody = string(digest(MD_MD5, message)))
+               MD5OfMessageBody = string(digest(MD_MD5, message)),
+               options...
+       )
 end
 
 function sqs_send_message(queue::AWSQueue, message::String, groupId::String)

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -187,9 +187,10 @@ end
 
 Send a `message` to a queue.
 """
-function sqs_send_message(queue::AWSQueue, message)
+function sqs_send_message(queue::AWSQueue, message::String, options...)
 
     sqs(queue, "SendMessage",
+               options,
                MessageBody = message,
                MD5OfMessageBody = string(digest(MD_MD5, message)))
 end


### PR DESCRIPTION
I couldn't send message to a FIFO queue with the master code, because this type of queue requires MessageGroupId parameter.
I just proposed options... to the sqs_send_message function so it doesn't affect the usage.

Maybe there exist a smarter way to do this. No need to merge this if you have better solutions.
Thanks