### PR TITLE
Pass options when sending messages to SQS queue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AWSSQS"
 uuid = "6e80b5ca-5733-51f9-999e-c18680912812"
 license = "MIT"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -115,10 +115,10 @@ sqs_send_message(q, "my message")
 ```
 """
 function sqs_create_queue(aws::AWSConfig, name; options...)
-    query = Dict("QueueName" => name)
+    query = Dict{String, String}("QueueName" => name)
 
     for (i, (k, v)) in enumerate(options)
-        query["Attribute.$i.Name"] = k
+        query["Attribute.$i.Name"] = string(k)
         query["Attribute.$i.Value"] = v
     end
 
@@ -168,12 +168,15 @@ end
     sqs_send_message(::AWSQueue, message)
 
 Send a `message` to a queue.
+
+```
+sqs_send_message(queue, "Hello!", Dict(:MessageGroupId=>"Some_UUID"))
+```
 """
-function sqs_send_message(queue::AWSQueue, message)
-    sqs(queue, "SendMessage",
-        MessageBody = message,
-        MD5OfMessageBody = string(digest(MD_MD5, message))
-   )
+function sqs_send_message(queue::AWSQueue, message::String, options...)
+    sqs(queue, "SendMessage";
+        MessageBody=message, MD5OfMessageBody=string(digest(MD_MD5, message)), options...
+    )
 end
 
 

--- a/test/queue.jl
+++ b/test/queue.jl
@@ -1,12 +1,44 @@
-create_queue(; queue_name="ocaws-jl-test-queue-" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))) = sqs_create_queue(aws, queue_name)
-
 function cleanup_queues()
     for q in sqs_list_queues(aws, "ocaws-jl-test-queue-")
         sqs_delete_queue(q)
     end
 end
 
+@testset "FIFO Queue" begin
+    create_fifo_queue(; queue_name="ocaws-jl-test-queue-" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ")) * ".fifo") = sqs_create_queue(aws, queue_name; Dict(:FifoQueue => "true")...)
+
+    @testset "Create FIFO Queue" begin
+        queue_name = "ocaws-jl-test-queue-" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ")) * ".fifo"
+        created_queue = create_fifo_queue(queue_name=queue_name)
+        fetched_queue = sqs_get_queue(aws, queue_name)
+
+        @test created_queue[:resource] == fetched_queue[:resource]
+    end
+
+    @testset "Send Message" begin
+        queue = create_fifo_queue()
+
+        options = Dict(
+            :MessageGroupId => "1aaa11aa-11aa-11a1-aa1a-111aa1a1a111",
+            :MessageDeduplicationId => "1aaa11aa-11aa-11a1-aa1a-111aa1a1a111"
+        )
+        sqs_send_message(queue, "Hello!", options...)
+        message = sqs_receive_message(queue)
+
+        @test message[:message] == "Hello!"
+    end
+
+    @testset "Queue Attributes" begin
+        queue = create_fifo_queue()
+        info = sqs_get_queue_attributes(queue)
+
+        @test info["FifoQueue"] == "true"
+    end
+end
+
 @testset "Queue" begin
+    create_queue(; queue_name="ocaws-jl-test-queue-" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))) = sqs_create_queue(aws, queue_name)
+
     @testset "Create Queue" begin
         queue_name = "ocaws-jl-test-queue-" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))
         created_queue = create_queue(queue_name=queue_name)
@@ -29,9 +61,13 @@ end
 
         msgs = repeat(["test message"], outer=num_messages)
         sqs_send_message_batch(queue, msgs)
-        message_count = sqs_count(queue)
 
+        message_count = sqs_count(queue)
         @test message_count == num_messages
+
+        while (m=sqs_receive_message(queue)) != nothing
+            @test m[:message] == "test message"
+        end
     end
 
     @testset "Queue Attributes" begin
@@ -41,14 +77,14 @@ end
         @test info["ApproximateNumberOfMessages"] == "0"
     end
 
-    @testset "Delete Queues" begin
+    @testset "Delete Queue" begin
         queue_name = "ocaws-jl-test-queue-" * lowercase(Dates.format(now(Dates.UTC), "yyyymmddTHHMMSSZ"))
         queue = create_queue(queue_name=queue_name)
         sqs_delete_queue(queue)
-
         deleted_queue = sqs_get_queue(aws, queue_name)
+
         @test deleted_queue == nothing
     end
-
-    cleanup_queues()
 end
+
+cleanup_queues()


### PR DESCRIPTION
Based off of #13 
Updated version of #10 since I do not have permissions to push to that fork.

---

Added the option to pass `options` to `sqs_send_message()`, this is needed for `Fifo Queues` as they require `MessageGroupId` and `MessageDeduplicationId`.