### PR TITLE
Add sqs_change_message_visibility

### DIFF
--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -250,7 +250,7 @@ end
 Change message visibility
 """
 function sqs_change_message_visibility(queue::AWSQueue, message, visibility_timeout)
-    sqs(queue, "ChangeMessageVisibility", VisibilityTimeout=visibility_timeout, ReceiptHandle = message[:handle])
+    sqs(queue, "ChangeMessageVisibility", VisibilityTimeout=visibility_timeout, ReceiptHandle=message[:handle])
 end
 
 """

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -247,7 +247,8 @@ end
 """
     sqs_change_message_visibility(::AWSQueue, message, visibility_timeout)
 
-Change message visibility
+Change the amount of time before a message can be re-read from a queue.
+Default message visibility timeout is 30 seconds, minimum is 0 seconds, maximum is 12 hours.
 """
 function sqs_change_message_visibility(queue::AWSQueue, message, visibility_timeout)
     sqs(queue, "ChangeMessageVisibility", VisibilityTimeout=visibility_timeout, ReceiptHandle=message[:handle])

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -247,7 +247,7 @@ end
 """
     sqs_change_message_visibility(::AWSQueue, message, visibility_timeout)
 
-Delete a `message` from a queue.
+Change message visibility
 """
 function sqs_change_message_visibility(queue::AWSQueue, message, visibility_timeout)
     sqs(queue, "ChangeMessageVisibility", VisibilityTimeout=visibility_timeout, ReceiptHandle = message[:handle])

--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -15,7 +15,7 @@ module AWSSQS
 export sqs_arn, sqs_busy_count, sqs_count, sqs_create_queue, sqs_delete_message,
     sqs_delete_queue, sqs_flush, sqs_get_queue, sqs_get_queue_attributes, sqs_list_queues,
     sqs_messages, sqs_name, sqs_receive_message, sqs_send_message, sqs_send_message_batch,
-    sqs_set_policy
+    sqs_set_policy, sqs_change_message_visibility
 
 using AWSCore
 using SymDict
@@ -244,6 +244,14 @@ function sqs_delete_message(queue::AWSQueue, message)
     sqs(queue, "DeleteMessage", ReceiptHandle = message[:handle])
 end
 
+"""
+    sqs_change_message_visibility(::AWSQueue, message, visibility_timeout)
+
+Delete a `message` from a queue.
+"""
+function sqs_change_message_visibility(queue::AWSQueue, message, visibility_timeout)
+    sqs(queue, "ChangeMessageVisibility", VisibilityTimeout=visibility_timeout, ReceiptHandle = message[:handle])
+end
 
 """
     sqs_flush(::AWSQueue)

--- a/test/queue.jl
+++ b/test/queue.jl
@@ -85,6 +85,18 @@ end
 
         @test deleted_queue == nothing
     end
+
+    @testset "Change Message Visibility" begin
+        queue = create_queue()
+        sqs_send_message(queue, "Hello!")
+        message = sqs_receive_message(queue)
+        @test message[:message] == "Hello!"
+
+        sqs_change_message_visibility(queue, message, 0)
+
+        message = sqs_receive_message(queue)
+        @test message[:message] == "Hello!"
+    end
 end
 
 cleanup_queues()

--- a/test/queue.jl
+++ b/test/queue.jl
@@ -86,16 +86,49 @@ end
         @test deleted_queue == nothing
     end
 
-    @testset "Change Message Visibility" begin
+@testset "Message Visibility" begin
         queue = create_queue()
-        sqs_send_message(queue, "Hello!")
-        message = sqs_receive_message(queue)
-        @test message[:message] == "Hello!"
+        message = "Hello!"
 
-        sqs_change_message_visibility(queue, message, 0)
+        @testset "Default" begin
+            sqs_send_message(queue, message)
+            response = sqs_receive_message(queue)
 
-        message = sqs_receive_message(queue)
-        @test message[:message] == "Hello!"
+            @test response[:message] == message
+
+            response = sqs_receive_message(queue)
+
+            @test response == nothing
+        end
+
+        @testset "0 seconds" begin
+            sqs_send_message(queue, message)
+            response = sqs_receive_message(queue)
+
+            @test response[:message] == message
+
+            sqs_change_message_visibility(queue, response, 0)
+            response = sqs_receive_message(queue)
+
+            @test response[:message] == message
+        end
+
+        @testset "3 seconds" begin
+            sqs_send_message(queue, message)
+            response = sqs_receive_message(queue)
+
+            @test response[:message] == message
+
+            sqs_change_message_visibility(queue, response, 3)
+            response = sqs_receive_message(queue)
+
+            @test response == nothing
+            
+            sleep(3)
+            response = sqs_receive_message(queue)
+
+            @test response[:message] == message
+        end
     end
 end
 


### PR DESCRIPTION
Add function to change message visibility time for handling jobs with dynamic running duration

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html#processing-messages-timely-manner