### PR TITLE
Add MessageId to message object as id

### DIFF
--- a/src/AWSSQS.jl
+++ b/src/AWSSQS.jl
@@ -194,7 +194,7 @@ end
 """
     sqs_receive_message(::AWSQueue)
 
-Returns a `Dict` containing `:message` and `:handle`
+Returns a `Dict` containing `:message`, `:id` and `:handle`
 or `nothing` if the queue is empty.
 
 ```
@@ -212,11 +212,12 @@ function sqs_receive_message(queue::AWSQueue)
     end
 
     handle  = r[1]["ReceiptHandle"]
+    id      = r[1]["MessageId"]
     message = r[1]["Body"]
     md5     = r[1]["MD5OfBody"]
 
     @assert md5 == bytes2hex(digest(MD_MD5, message))
-    @SymDict(message, handle)
+    @SymDict(message, id, handle)
 end
 
 

--- a/test/queue.jl
+++ b/test/queue.jl
@@ -25,7 +25,7 @@ end
         sqs_send_message(queue, "Hello!", options...)
         message = sqs_receive_message(queue)
 
-        @test haskey(message, :id) && isempty(message[:id])
+        @test haskey(message, :id) && !isempty(message[:id])
         @test message[:message] == "Hello!"
     end
 
@@ -53,7 +53,7 @@ end
         sqs_send_message(queue, "Hello!")
         message = sqs_receive_message(queue)
 
-        @test haskey(message, :id) && isempty(message[:id])
+        @test haskey(message, :id) && !isempty(message[:id])
         @test message[:message] == "Hello!"
     end
 
@@ -68,7 +68,7 @@ end
         @test message_count == num_messages
 
         while (m=sqs_receive_message(queue)) != nothing
-            @test haskey(m, :id) && isempty(m[:id])
+            @test haskey(m, :id) && !isempty(m[:id])
             @test m[:message] == "test message"
         end
     end

--- a/test/queue.jl
+++ b/test/queue.jl
@@ -25,6 +25,7 @@ end
         sqs_send_message(queue, "Hello!", options...)
         message = sqs_receive_message(queue)
 
+        @test haskey(message, :id) && isempty(message[:id])
         @test message[:message] == "Hello!"
     end
 
@@ -52,6 +53,7 @@ end
         sqs_send_message(queue, "Hello!")
         message = sqs_receive_message(queue)
 
+        @test haskey(message, :id) && isempty(message[:id])
         @test message[:message] == "Hello!"
     end
 
@@ -66,6 +68,7 @@ end
         @test message_count == num_messages
 
         while (m=sqs_receive_message(queue)) != nothing
+            @test haskey(m, :id) && isempty(m[:id])
             @test m[:message] == "test message"
         end
     end


### PR DESCRIPTION
*Background*

I have a use case where I need the message ID of a particular message. This PR adds MessageId to the list of fields returned by the message object

*Changes*
* Add MessageId to the object returned by `sqs_receive_message` as the field `id`