### PR TITLE
Add nightly and lastest Julia versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
 - osx
 julia:
 - 1.0
+- 1
+- nightly
 notifications:
   email: false
 env:


### PR DESCRIPTION
Testing why `AWSSQS.jl` is failing its CI for merge requests.